### PR TITLE
Add unexpected input to BdioReader error message

### DIFF
--- a/bdio/src/main/java/com/blackducksoftware/bdio/io/BdioReader.java
+++ b/bdio/src/main/java/com/blackducksoftware/bdio/io/BdioReader.java
@@ -113,7 +113,7 @@ public class BdioReader implements Closeable {
         // Start by finding the list of nodes
         JsonToken startingToken = jp.nextToken();
         if (startingToken != JsonToken.START_ARRAY) {
-            throw new IOException("expected input to start with an array (found JsonToken." + startingToken + ")");
+            throw new IOException("expected input to start with an array (found " + startingToken + ")");
         }
     }
 

--- a/bdio/src/main/java/com/blackducksoftware/bdio/io/BdioReader.java
+++ b/bdio/src/main/java/com/blackducksoftware/bdio/io/BdioReader.java
@@ -111,8 +111,9 @@ public class BdioReader implements Closeable {
         jp = new ObjectMapper().getFactory().createParser(in);
 
         // Start by finding the list of nodes
-        if (jp.nextToken() != JsonToken.START_ARRAY) {
-            throw new IOException("expected input to start with an array");
+        JsonToken startingToken = jp.nextToken();
+        if (startingToken != JsonToken.START_ARRAY) {
+            throw new IOException("expected input to start with an array (found JsonToken." + startingToken + ")");
         }
     }
 


### PR DESCRIPTION
When the BdioReader encounters something other than the start of an array, it throws an IOException. Clients attempting to debug this issue would be helped by the error message containing additional information about the unexpected element that was encountered