### PR TITLE
Make LegacyUtilities public

### DIFF
--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/LegacyUtilities.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/LegacyUtilities.java
@@ -49,7 +49,7 @@ import com.google.common.collect.Multimap;
  *
  * @author jgustie
  */
-class LegacyUtilities {
+public class LegacyUtilities {
 
     /**
      * This module makes the configured object mapper behave like the one used to parse legacy scan container objects.


### PR DESCRIPTION
Synopsys Detect needs to utilize the LegacyUtilities class to generate valid BDIO 2 documents for consumption by Black Duck.