### PR TITLE
Updates for Gradle 5.2 to handle MavenCentral publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ allprojects {
 	apply plugin: 'eclipse'
 	apply plugin: 'nebula.dependency-recommender'
 	apply plugin: 'maven-publish'
-	apply plugin: 'com.jfrog.artifactory'
+	apply plugin: 'com.jfrog.artifactory'	
 
 	repositories {
 		jcenter()
@@ -70,5 +70,4 @@ subprojects {
 			}
 		}
 	}
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 		classpath 'com.netflix.nebula:nebula-dependency-recommender:5.1.0'
 		classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.5'
 		classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
-		classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.6.0"
+		classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.13.0"
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'bdio'
 include 'bdio2', 'bdio-reactor', 'bdio-rxjava', 'bdio-tinkerpop', 'bdio-tool', 'bdio-test'


### PR DESCRIPTION
Gradle 5.2 or later is required for MavenCentral publishing with GPG signing, in an elegant and secure way (done internally by Synopsys).  As well, the Artifactory plugin needs to be updated to handle this change.