### PR TITLE
HUB-29341 : switching file scheme for BDIO library from seveZ to sevenz and formalize the usage of 'sevenz' as a scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please refer to the [project wiki][wiki].
 $ git clone git@github.com:blackducksoftware/bdio.git bdio-libraries
 $ cd bdio-libraries/
 $ docker build -t blackducksoftware/bdio-tinkerpop-db bdio-tinkerpop-db/
-$ docker run -d -p 5432:5432 blackducksoftware/bdio-tinkerpop-db
+$ docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 blackducksoftware/bdio-tinkerpop-db
 $ ./gradlew build
 ````
 

--- a/bdio-tool/build.gradle
+++ b/bdio-tool/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compile 'com.squareup.okhttp3:okhttp'
 	compile 'org.apache.tinkerpop:tinkergraph-gremlin'
 	compile 'org.slf4j:slf4j-nop'
+	compile 'javax.activation:javax.activation-api'
 
 	testCompile 'junit:junit'
 }

--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/LegacyUtilities.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/LegacyUtilities.java
@@ -244,7 +244,7 @@ public class LegacyUtilities {
                     case "arj":
                         return "arj";
                     case "7z":
-                        return "sevenZ";
+                        return "sevenz";
                     default:
                         // Keep looking
                         end = start;

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -23,3 +23,4 @@ org.slf4j:slf4j-log4j12 = 1.7.7
 org.slf4j:slf4j-nop = 1.7.7
 org.slf4j:slf4j-simple = 1.7.21
 org.umlg:sqlg-postgres = 1.5.2
+javax.activation:javax.activation-api=1.2.0


### PR DESCRIPTION
There is discrepancy in file scheme set by BDIO and HID for 7z archive files. BDIO is setting “sevenZ” as file scheme for 7z archive where as  HID is returning “sevenz” as file scheme for the same path that have “sevenZ” as file scheme.