### PR TITLE
 Fix scan type mapping for package manager and binary scans.

### DIFF
--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/Bdio.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/Bdio.java
@@ -1057,7 +1057,11 @@ public class Bdio {
         /**
          * A Signature scan.
          */
-        SIGNATURE("SIGNATURE");
+        SIGNATURE("SIGNATURE"),
+        /**
+         * A Binary scan.
+         */
+        BINARY("BINARY");
 
         private final String value;
 

--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/BdioEmitter.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/BdioEmitter.java
@@ -46,7 +46,7 @@ public class BdioEmitter implements Emitter {
 
     public BdioEmitter(InputStream in) {
         reader = new BdioReader(in);
-        context =  BdioContext.getDefault();
+        context = BdioContext.getDefault();
     }
 
     /**
@@ -101,10 +101,12 @@ public class BdioEmitter implements Emitter {
                             .orElse(null);
 
                     if (productList != null) {
-                        if (productList.primary().name().equalsIgnoreCase("Detect")) {
-                            scanType = Bdio.ScanType.PACKAGE_MANAGER.name();
-                        } else if (productList.primary().name().equalsIgnoreCase("ScanClient")) {
+                        if (productList.primary().name().equalsIgnoreCase("ScanClient")) {
                             scanType = Bdio.ScanType.SIGNATURE.name();
+                        } else if (productList.primary().name().equalsIgnoreCase("Protecode-SC")) {
+                            scanType = Bdio.ScanType.BINARY.name();
+                        } else {
+                            scanType = Bdio.ScanType.PACKAGE_MANAGER.name();
                         }
                     }
                 }


### PR DESCRIPTION
Since the scan type field is mandatory now and the product `Detect` is removed from product list from BDIO 2.0. The emitter couldn't determine the correct scan type, so it was throwing errors while processing the document. 

- Added a new scan type `BINARY` for binary scans, other wise the field can't be null so the bdio file processing will fail.
- Fixed the mapping and added tests to verify the same.