### PR TITLE
If scan type is not set or cannot be determined by metadata set it to package manager as default.

### DIFF
--- a/bdio-rxjava/src/test/java/com/blackducksoftware/bdio2/rxjava/BdioDocumentFromModelTest.java
+++ b/bdio-rxjava/src/test/java/com/blackducksoftware/bdio2/rxjava/BdioDocumentFromModelTest.java
@@ -129,6 +129,19 @@ public class BdioDocumentFromModelTest {
 
         // Validate that the extracted scanType is correct
         assertThat(doc.metadata(doc.read(out.getInputStream())).singleOrError().blockingGet().scanType()).isEqualTo(Bdio.ScanType.BINARY.getValue());
+
+        // Verify mapping of a Scan without product information
+        metadata = BdioMetadata.createRandomUUID();
+        metadata.publisher(null);
+        out = new HeapOutputStream();
+        doc = new RxJavaBdioDocument(new BdioContext.Builder().build());
+
+        Flowable.just(new File("http://example.com/files/1"))
+                .buffer(1)
+                .subscribe(doc.write(metadata, new BdioWriter.BdioFile(out)));
+
+        // Validate that the extracted scanType is correct
+        assertThat(doc.metadata(doc.read(out.getInputStream())).singleOrError().blockingGet().scanType()).isEqualTo(Bdio.ScanType.PACKAGE_MANAGER.getValue());
     }
 
 }

--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/BdioEmitter.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/BdioEmitter.java
@@ -105,16 +105,15 @@ public class BdioEmitter implements Emitter {
                             scanType = Bdio.ScanType.SIGNATURE.name();
                         } else if (productList.primary().name().equalsIgnoreCase("Protecode-SC")) {
                             scanType = Bdio.ScanType.BINARY.name();
-                        } else {
-                            scanType = Bdio.ScanType.PACKAGE_MANAGER.name();
                         }
                     }
+
+                    // The above block should have figured out the scan type, if not setting the default scan type to package manager.
+                    if (scanType == null) {
+                        scanType = Bdio.ScanType.PACKAGE_MANAGER.name();
+                    }
                 }
-                // The above block should have figured out the scan type, there is no use is adding a null to the map because it will be
-                // ignored.
-                if (scanType != null) {
-                    context.putFieldValue((Map<String, Object>) object, JsonLdConsts.TYPE, scanType);
-                }
+                context.putFieldValue((Map<String, Object>) object, JsonLdConsts.TYPE, scanType);
             }
         }
     }


### PR DESCRIPTION
If scan type is not set and it cannot be determined based on product information set package manager as default scan type.