### PR TITLE
HUB-30952: Remove Vulenrability and change upgrade to JAVA11

### DIFF
--- a/bdio-test/build.gradle
+++ b/bdio-test/build.gradle
@@ -6,5 +6,9 @@ dependencies {
 	compile 'com.google.code.findbugs:jsr305'
 	compile 'com.google.guava:guava'
 	compile 'org.apache.tinkerpop:gremlin-core'
+	constraints {
+		compile 'org.apache.tinkerpop:gremlin-shaded:3.5.1'
+		compile 'com.fasterxml.jackson.core:jackson-annotations:2.12.3'
+	}
 	compile 'org.slf4j:slf4j-simple'
 }

--- a/bdio-tinkerpop/build.gradle
+++ b/bdio-tinkerpop/build.gradle
@@ -4,6 +4,10 @@ dependencies {
 	compile project(':bdio-rxjava')
 	compile 'com.blackducksoftware.magpie:magpie'
 	compile 'org.apache.tinkerpop:gremlin-core'
+	constraints {
+		compile 'org.apache.tinkerpop:gremlin-shaded:3.5.1'
+		compile 'com.fasterxml.jackson.core:jackson-annotations:2.12.3'
+	}
 	compile 'org.flywaydb:flyway-core'
 	compile 'org.umlg:sqlg-postgres'
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 	dependencies { 
         classpath 'com.netflix.nebula:nebula-dependency-recommender:5.1.0'
 		classpath 'com.netflix.nebula:nebula-publishing-plugin:17.3.2'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.13.0"
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.13.0'
 	}
 }
 
@@ -40,7 +40,7 @@ subprojects {
 	apply plugin: 'java'
 	apply plugin: 'nebula.source-jar'
 
-	sourceCompatibility = 1.8
+	sourceCompatibility = JavaVersion.VERSION_11
 
 	tasks.withType(JavaCompile) {
 		options.compilerArgs << '-Xlint:all'

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -1,8 +1,8 @@
 com.blackducksoftware.magpie:magpie = 0.6.0
 com.blackducksoftware.magpie:magpie-test = 0.6.0
-com.fasterxml.jackson.core:jackson-annotations = 2.9.0
-com.fasterxml.jackson.core:jackson-core = 2.9.8
-com.fasterxml.jackson.core:jackson-databind = 2.9.8
+com.fasterxml.jackson.core:jackson-annotations = 2.12.3
+com.fasterxml.jackson.core:jackson-core = 2.12.3
+com.fasterxml.jackson.core:jackson-databind = 2.12.3
 com.github.jsonld-java:jsonld-java = 0.12.3
 com.google.code.findbugs:jsr305 = 2.0.3
 com.google.guava:guava = 23.3-jre

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip


### PR DESCRIPTION
Upgrading to java 11 and set constraints on the gremlin-shaded to use 3.5.1 version. 

Upgrading the complete version was giving a lot of errors, which we would need to take  care of as a part of other tickets. This change is just trying to put a patch for the vulnerability.