### PR TITLE
Revert to using Java 8

### DIFF
--- a/bdio-test/build.gradle
+++ b/bdio-test/build.gradle
@@ -6,9 +6,5 @@ dependencies {
 	compile 'com.google.code.findbugs:jsr305'
 	compile 'com.google.guava:guava'
 	compile 'org.apache.tinkerpop:gremlin-core'
-	constraints {
-		compile 'org.apache.tinkerpop:gremlin-shaded:3.5.1'
-		compile 'com.fasterxml.jackson.core:jackson-annotations:2.12.3'
-	}
 	compile 'org.slf4j:slf4j-simple'
 }

--- a/bdio-tinkerpop/build.gradle
+++ b/bdio-tinkerpop/build.gradle
@@ -4,10 +4,6 @@ dependencies {
 	compile project(':bdio-rxjava')
 	compile 'com.blackducksoftware.magpie:magpie'
 	compile 'org.apache.tinkerpop:gremlin-core'
-	constraints {
-		compile 'org.apache.tinkerpop:gremlin-shaded:3.5.1'
-		compile 'com.fasterxml.jackson.core:jackson-annotations:2.12.3'
-	}
 	compile 'org.flywaydb:flyway-core'
 	compile 'org.umlg:sqlg-postgres'
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
 	apply plugin: 'java'
 	apply plugin: 'nebula.source-jar'
 
-	sourceCompatibility = JavaVersion.VERSION_11
+	sourceCompatibility = JavaVersion.VERSION_1_8
 
 	tasks.withType(JavaCompile) {
 		options.compilerArgs << '-Xlint:all'

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -14,6 +14,7 @@ io.reactivex.rxjava2:rxjava = 2.1.9
 junit:junit = 4.12
 org.apache.tinkerpop:gremlin-core = 3.3.3
 org.apache.tinkerpop:tinkergraph-gremlin = 3.3.3
+org.apache.tinkerpop:gremlin-shaded=3.5.1
 org.flywaydb:flyway-core = 4.2.0
 org.mockito:mockito-core = 1.9.5
 org.reactivestreams:reactive-streams = 1.0.2


### PR DESCRIPTION
We would still want to continue using Java 8, since the change could be risky for the other users of the library. 