### PR TITLE
HUB-31899. Introduce project related fields to bdio metadata

### DIFF
--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/Bdio.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/Bdio.java
@@ -596,6 +596,28 @@ public class Bdio {
         platform("https://blackducksoftware.github.io/bdio#hasPlatform", Container.single),
 
         /**
+         * Name of the project this BDIO document is associated with.
+         */
+        @Domain(metadata = true)
+        @DataPropertyRange(Datatype.Default)
+        project("https://blackducksoftware.github.io/bdio#hasProject", Container.single),
+
+        /**
+         * Name of the project group this BDIO document is associated with.
+         */
+        @Domain(metadata = true)
+        @DataPropertyRange(Datatype.Default)
+        projectGroup("https://blackducksoftware.github.io/bdio#hasProjectGroup", Container.single),
+
+        /**
+         * Name of the project version this BDIO document is associated with.
+         */
+        @Domain(metadata = true)
+        @DataPropertyRange(Datatype.Default)
+        projectVersion("https://blackducksoftware.github.io/bdio#hasProjectVersion", Container.single),
+
+        
+        /**
          * The tool which published the BDIO document.
          */
         @Domain(metadata = true)

--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/BdioMetadata.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/BdioMetadata.java
@@ -336,5 +336,29 @@ public final class BdioMetadata extends BdioObject {
         putFieldValue(Bdio.DataProperty.sourceTag, sourceTag);
         return this;
     }
+    
+    /**
+     * Sets the project name associated with this named graph.
+     */
+    public BdioMetadata project(@Nullable String project) {
+        putFieldValue(Bdio.DataProperty.project, project);
+        return this;
+    }
+    
+    /**
+     * Sets the project group associated with this named graph.
+     */
+    public BdioMetadata projectGroup(@Nullable String projectGroup) {
+        putFieldValue(Bdio.DataProperty.projectGroup, projectGroup);
+        return this;
+    }
+    
+    /**
+     * Sets the project version associated with this named graph.
+     */
+    public BdioMetadata projectVersion(@Nullable String projectVersion) {
+        putFieldValue(Bdio.DataProperty.projectVersion, projectVersion);
+        return this;
+    }
 
 }

--- a/bdio2/src/main/resources/com/blackducksoftware/bdio2/bdio-context-2.1.jsonld
+++ b/bdio2/src/main/resources/com/blackducksoftware/bdio2/bdio-context-2.1.jsonld
@@ -154,6 +154,9 @@
       "@id" : "https://blackducksoftware.github.io/bdio#hasPlatform",
       "@type" : "https://blackducksoftware.github.io/bdio#Products"
     },
+    "project" : "https://blackducksoftware.github.io/bdio#hasProject",
+    "projectGroup" : "https://blackducksoftware.github.io/bdio#hasProjectGroup",
+    "projectVersion" : "https://blackducksoftware.github.io/bdio#hasProjectVersion",
     "publisher" : {
       "@id" : "https://blackducksoftware.github.io/bdio#hasPublisher",
       "@type" : "https://blackducksoftware.github.io/bdio#Products"

--- a/docs/spec/02.Model.txt
+++ b/docs/spec/02.Model.txt
@@ -330,6 +330,24 @@
 : _Domain: `Component`, `Container`, `File`, `Project`, `Repository`, `Vulnerability`_
 : _Range: `Products`_
 
+`project`
+: `https://blackducksoftware.github.io/bdio#hasProject`
+: Name of the project this BDIO document is associated with.
+: _Domain: `@graph`_
+: _Range: `Default`_
+
+`projectGroup`
+: `https://blackducksoftware.github.io/bdio#hasProjectGroup`
+: Name of the project group this BDIO document is associated with.
+: _Domain: `@graph`_
+: _Range: `Default`_
+
+`projectVersion`
+: `https://blackducksoftware.github.io/bdio#hasProjectVersion`
+: Name of the project version this BDIO document is associated with.
+: _Domain: `@graph`_
+: _Range: `Default`_
+
 `publisher`
 : `https://blackducksoftware.github.io/bdio#hasPublisher`
 : The tool which published the BDIO document.


### PR DESCRIPTION
Project name, project version name, and project group name fields are added to bdio metadata. 
Currently these data are passed as http headers (project name and project version name), which has certain disadvantages(
see Seth Katzman comment to HUB-31899 jira issue). Also, project group name needs to be passed along with project name and project version name to enable policy rules evaluation set up for project groups.