### PR TITLE
HUBB-33373: Added matchConfidenceThreshold field to bdio

### DIFF
--- a/bdio-rxjava/src/test/java/com/blackducksoftware/bdio2/rxjava/BdioDocumentFromModelTest.java
+++ b/bdio-rxjava/src/test/java/com/blackducksoftware/bdio2/rxjava/BdioDocumentFromModelTest.java
@@ -202,4 +202,28 @@ public class BdioDocumentFromModelTest {
          assertThat(actualCorrelationId).isEqualTo(expectedCorrelationId);
     }
 
+    @Test
+    public void testMatchConfidenceThreshold() {
+         Long expectedMatchConfidenceThreshold = 15L;
+
+         BdioMetadata metadata = BdioMetadata.createRandomUUID();
+         metadata.matchConfidenceThreshold(expectedMatchConfidenceThreshold);
+
+         HeapOutputStream out = new HeapOutputStream();
+         RxJavaBdioDocument doc = new RxJavaBdioDocument(new BdioContext.Builder().build());
+
+         // write bdio document (including metadata) to in memory output stream
+         Flowable.just(new File("http://example.com/files/1"))
+                 .buffer(1)
+                 .subscribe(doc.write(metadata, new BdioWriter.BdioFile(out)));
+
+         // read bdio document and extract metadata fields
+         BdioContext context = new BdioContext.Builder().expandContext(Bdio.Context.DEFAULT).build();
+         BdioMetadata actualMetadata = doc.metadata(doc.read(out.getInputStream())).singleOrError().blockingGet();
+
+         Long actualMatchConfidenceThreshold = (Long) context.getFieldValue(Bdio.DataProperty.matchConfidenceThreshold, actualMetadata).collect(MoreCollectors.toOptional()).get();
+
+         assertThat(actualMatchConfidenceThreshold).isEqualTo(expectedMatchConfidenceThreshold);
+    }
+
 }

--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/Bdio.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/Bdio.java
@@ -452,6 +452,13 @@ public class Bdio {
         correlationId("https://blackducksoftware.github.io/bdio#hasCorrelationId", Container.single),
 
         /**
+         * matchConfidenceThreshold used to filter matches
+         */
+        @Domain(metadata = true)
+        @DataPropertyRange(Datatype.Long)
+        matchConfidenceThreshold("https://blackducksoftware.github.io/bdio#hasMatchConfidenceThreshold", Container.single),
+
+        /**
          * The date and time creation of an entity occurred.
          */
         @Domain(value = { Class.Annotation, Class.File, Class.Vulnerability }, metadata = true)

--- a/bdio2/src/main/java/com/blackducksoftware/bdio2/BdioMetadata.java
+++ b/bdio2/src/main/java/com/blackducksoftware/bdio2/BdioMetadata.java
@@ -369,4 +369,11 @@ public final class BdioMetadata extends BdioObject {
         return this;
     }
 
+    /**
+     * Sets the matchConfidenceThreshold value to filter the matches.
+     */
+    public BdioMetadata matchConfidenceThreshold(@Nullable Long matchConfidenceThreshold) {
+        putFieldValue(Bdio.DataProperty.matchConfidenceThreshold, matchConfidenceThreshold);
+        return this;
+    }
 }

--- a/bdio2/src/main/resources/com/blackducksoftware/bdio2/bdio-context-2.1.jsonld
+++ b/bdio2/src/main/resources/com/blackducksoftware/bdio2/bdio-context-2.1.jsonld
@@ -104,6 +104,10 @@
     },
     "context" : "https://blackducksoftware.github.io/bdio#hasContext",
     "correlationId" : "https://blackducksoftware.github.io/bdio#hasCorrelationId",
+    "matchConfidenceThreshold" : {
+      "@id" : "https://blackducksoftware.github.io/bdio#hasMatchConfidenceThreshold",
+      "@type" : "xsd:long"
+    },
     "creationDateTime" : {
       "@id" : "https://blackducksoftware.github.io/bdio#hasCreationDateTime",
       "@type" : "xsd:dateTime"

--- a/docs/spec/02.Model.txt
+++ b/docs/spec/02.Model.txt
@@ -221,6 +221,12 @@
 : _Domain: `@graph`_
 : _Range: `Default`_
 
+`matchConfidenceThreshold`
+: `https://blackducksoftware.github.io/bdio#hasMatchConfidenceThreshold`
+: MatchConfidenceThreshold is a percentage value, based on which match results use to get filtered out.
+: _Domain: `@graph`_
+: _Range: `Long`_
+
 `creationDateTime`
 : `https://blackducksoftware.github.io/bdio#hasCreationDateTime`
 : The date and time creation of an entity occurred.


### PR DESCRIPTION
A new field is being added in the bdio meta info which will be used in the scan client to pass a percentage value to the backend.
This value represents a threshold value which will be used to filter the match results. 