### PR TITLE
HUB-33373: Version change to make the new matchConfidenceThreshold fi…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.blackducksoftware.bdio
-version=3.2.3-SNAPSHOT
+version=3.2.3
 description=Black Duck I/O Project
 
 specVersion=2.1.0-beta


### PR DESCRIPTION
Version change to make the new matchConfidenceThreshold field available in non snapshot artifact before upgrading snapshot minor version to 3.2.4-snapshot