### PR TITLE
Adds proper error surfacing for bdio entry that exceeds size limit

### DIFF
--- a/bdio-rxjava/src/main/java/com/blackducksoftware/bdio2/rxjava/RxJavaBdioDocument.java
+++ b/bdio-rxjava/src/main/java/com/blackducksoftware/bdio2/rxjava/RxJavaBdioDocument.java
@@ -75,7 +75,9 @@ public class RxJavaBdioDocument extends BdioDocument {
     public Flowable<BdioMetadata> metadata(Publisher<Object> inputs) {
         return jsonLd(Flowable.fromPublisher(inputs).map(BdioDocument::toMetadata))
                 .expand().flatMapIterable(BdioDocument::unfoldExpand)
-                .onErrorReturn(BdioMetadata::new)
+                .onErrorReturn((throwable) -> {
+                    throw new RuntimeException("Parsing failed with error", throwable);
+                })
                 .reduce(new BdioMetadata(), BdioMetadata::merge)
                 .toFlowable();
     }


### PR DESCRIPTION
This ensures that if a chunk exceeds the configured max read size, we throw an error that properly represents the issue.