### PR TITLE
HUB-40316. Enable non empty but blank file name

### DIFF
--- a/bdio-protobuf/src/main/java/com/blackducksoftware/bdio/proto/impl/AbstractProtobufBdioValidator.java
+++ b/bdio-protobuf/src/main/java/com/blackducksoftware/bdio/proto/impl/AbstractProtobufBdioValidator.java
@@ -53,7 +53,7 @@ public abstract class AbstractProtobufBdioValidator implements IProtobufBdioVali
     }
 
     protected void validate(ProtoFileNode node) {
-        requireNonBlank(FILE_NODE_CLASS, "name", node.getName());
+        requireNonEmpty(FILE_NODE_CLASS, "name", node.getName());
         requireNonBlank(FILE_NODE_CLASS, "path", node.getPath());
         requireNonBlank(FILE_NODE_CLASS, "uri", node.getUri());
         requireNonBlank(FILE_NODE_CLASS, "fileSystemType", node.getFileSystemType());
@@ -93,6 +93,12 @@ public abstract class AbstractProtobufBdioValidator implements IProtobufBdioVali
     private void requireNonNull(String className, String fieldName, Object value) {
         if (value == null) {
             throw new BdioValidationException("The field " + className + "." + fieldName + " must be non null: " + value);
+        }
+    }
+    
+    private void requireNonEmpty(String className, String fieldName, String value) {
+        if (StringUtils.isEmpty(value)) {
+            throw new BdioValidationException("The field " + className + "." + fieldName + " must not be empty: " + value);
         }
     }
 

--- a/bdio-protobuf/src/test/java/com/blackducksoftware/bdio/proto/ProtobufBdioV2ValidatorTest.java
+++ b/bdio-protobuf/src/test/java/com/blackducksoftware/bdio/proto/ProtobufBdioV2ValidatorTest.java
@@ -88,6 +88,23 @@ public class ProtobufBdioV2ValidatorTest {
 
         validator.validate(fileNode);
     }
+    
+    // tests that file name can be /r or /n or other non empty string that is considered to be blank - HUB-40316
+    @Test 
+    public void testValidateFileNode7() {
+    	ProtoFileNode fileNode = ProtoFileNode.newBuilder()
+                .setId(1L)
+                .setParentId(2L)
+                .setName(System.lineSeparator())
+                .setPath("path")
+                .setUri("uri")
+                .setFileSystemType("FILE")
+                .setSize(2L)
+                .build();
+
+    	validator.validate(fileNode);
+
+    }
 
     @Test
     public void testValidateComponentNode1() {


### PR DESCRIPTION
It turns out that file names like this '\r' or '\n'  are possible. The bdio jsonld format allows such values. I verified that the signatures generated while allowing such values (file names) in protobuf format, are the same as those generated in jsonld format (by old signature scanner), so we can consider such file names as valid.